### PR TITLE
Add region to instance info

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -110,6 +110,13 @@ class IntegrationRequest:
         return self._unit.received['instance-id']
 
     @property
+    def region(self):
+        """
+        The region reported for this request.
+        """
+        return self._unit.received['region']
+
+    @property
     def instance_tags(self):
         """
         Mapping of tag names to values (or `None`) to apply to this instance.

--- a/requires.py
+++ b/requires.py
@@ -54,7 +54,7 @@ class AWSRequires(Endpoint):
         update_config_enable_aws()
     ```
     """
-    _metadata_url = 'http://instance-data/latest/meta-data/'
+    _metadata_url = 'http://169.254.169.254/latest/meta-data/'
     _instance_id_url = urljoin(_metadata_url, 'instance-id')
     _az_url = urljoin(_metadata_url, 'placement/availability-zone')
 


### PR DESCRIPTION
The region is required because I guess instance IDs are not globally unique.