### PR TITLE
Rename security group and subnet tag interfaces to make clear what it actually tags

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -125,22 +125,22 @@ class IntegrationRequest:
         return dict(self._unit.received.get('instance-tags', {}))
 
     @property
-    def security_group_tags(self):
+    def instance_security_group_tags(self):
         """
-        Mapping of tag names to values (or `None`) to apply to all of this
-        instance's security groups.
+        Mapping of tag names to values (or `None`) to apply to this instance's
+        Juju unit security group.
         """
         # uses dict() here to make a copy, just to be safe
-        return dict(self._unit.received.get('security-group-tags', {}))
+        return dict(self._unit.received.get('instance-sec-grp-tags', {}))
 
     @property
-    def subnet_tags(self):
+    def instance_subnet_tags(self):
         """
-        Mapping of tag names to values (or `None`) to apply to all of this
-        instance's subnets.
+        Mapping of tag names to values (or `None`) to apply to this instance's
+        subnet.
         """
         # uses dict() here to make a copy, just to be safe
-        return dict(self._unit.received.get('subnet-tags', {}))
+        return dict(self._unit.received.get('instance-subnet-tags', {}))
 
     @property
     def requested_elb(self):

--- a/requires.py
+++ b/requires.py
@@ -138,7 +138,7 @@ class AWSRequires(Endpoint):
         self._to_publish['instance-tags'] = dict(tags)
         clear_flag(self.expand_name('ready'))
 
-    def request_security_group_tags(self, tags):
+    def request_instance_security_group_tags(self, tags):
         """
         Request that the given tags be applied to all of this instance's
         security groups.
@@ -146,10 +146,10 @@ class AWSRequires(Endpoint):
         # Parameters
         tags (dict): Mapping of tag names to values (or `None`).
         """
-        self._to_publish['security-group-tags'] = dict(tags)
+        self._to_publish['instance-sec-grp-tags'] = dict(tags)
         clear_flag(self.expand_name('ready'))
 
-    def request_subnet_tags(self, tags):
+    def request_instance_subnet_tags(self, tags):
         """
         Request that the given tags be applied to all of this instance's
         subnets.
@@ -157,7 +157,7 @@ class AWSRequires(Endpoint):
         # Parameters
         tags (dict): Mapping of tag names to values (or `None`).
         """
-        self._to_publish['subnet-tags'] = dict(tags)
+        self._to_publish['instance-subnet-tags'] = dict(tags)
         clear_flag(self.expand_name('ready'))
 
     def enable_elb(self):


### PR DESCRIPTION
Specifically, they only tag the single Juju unit security group and the single instance subnet.