### PR TITLE
Rename interface to aws-integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 # Overview
 
-This layer encapsulates the `aws` interface communciation protocol and provides
-an API for charms on either side of relations using this interface.
+This layer encapsulates the `aws-integration` interface communciation protocol
+and provides an API for charms on either side of relations using this
+interface.
 
 ## Usage
 
-In your charm's `layer.yaml`, ensure that `interface:aws` is included in the
-`includes` section:
+In your charm's `layer.yaml`, ensure that `interface:aws-integration` is
+included in the `includes` section:
 
 ```yaml
-includes: ['layer:basic', 'interface:aws']
+includes: ['layer:basic', 'interface:aws-integration']
 ```
 
 And in your charm's `metadata.yaml`, ensure that a relation endpoint is defined
-using the `aws` interface protocol:
+using the `aws-integration` interface protocol:
 
 ```yaml
 requires:
   aws:
-    interface: aws
+    interface: aws-integration
 ```
 
 For documentation on how to use the API for this interface, see:
 
 * [Requires API documentation](docs/requires.md)
-* [Provides API documentation](docs/provides.md) (this will only be used by the AWS charm)
+* [Provides API documentation](docs/provides.md) (this will only be used by the aws-integrator charm)

--- a/docs/provides.md
+++ b/docs/provides.md
@@ -2,7 +2,7 @@
 
 
 This is the provides side of the interface layer, for use only by the AWS
-integration charm itself.
+integrator charm itself.
 
 The flags that are set by the provides side of this interface are:
 
@@ -12,10 +12,10 @@ The flags that are set by the provides side of this interface are:
   whatever actions are necessary to satisfy those requests, and then mark
   them as complete.
 
-<h1 id="provides.AWSProvides">AWSProvides</h1>
+<h1 id="provides.AWSIntegrationProvides">AWSIntegrationProvides</h1>
 
 ```python
-AWSProvides(self, endpoint_name, relation_ids=None)
+AWSIntegrationProvides(self, endpoint_name, relation_ids=None)
 ```
 
 Example usage:
@@ -43,18 +43,18 @@ def handle_requests():
         request.mark_completed()
 ```
 
-<h2 id="provides.AWSProvides.application_names">application_names</h2>
+<h2 id="provides.AWSIntegrationProvides.application_names">application_names</h2>
 
 
 Set of names of all applications that are still joined.
 
-<h2 id="provides.AWSProvides.requests">requests</h2>
+<h2 id="provides.AWSIntegrationProvides.requests">requests</h2>
 
 
 A list of the new or updated `IntegrationRequests` that
 have been made.
 
-<h2 id="provides.AWSProvides.unit_instances">unit_instances</h2>
+<h2 id="provides.AWSIntegrationProvides.unit_instances">unit_instances</h2>
 
 
 Mapping of unit names to instance IDs and regions for all joined units.

--- a/docs/requires.md
+++ b/docs/requires.md
@@ -19,10 +19,10 @@ The flags that are set by the requires side of this interface are:
   running.  This flag is automatically removed if new integration features
   are requested.  It should not be removed by the charm.
 
-<h1 id="requires.AWSRequires">AWSRequires</h1>
+<h1 id="requires.AWSIntegrationRequires">AWSIntegrationRequires</h1>
 
 ```python
-AWSRequires(self, *args, **kwargs)
+AWSIntegrationRequires(self, *args, **kwargs)
 ```
 
 Example usage:
@@ -45,20 +45,20 @@ def aws_integration_ready():
     update_config_enable_aws()
 ```
 
-<h2 id="requires.AWSRequires.instance_id">instance_id</h2>
+<h2 id="requires.AWSIntegrationRequires.instance_id">instance_id</h2>
 
 
 This unit's instance-id.
 
-<h2 id="requires.AWSRequires.region">region</h2>
+<h2 id="requires.AWSIntegrationRequires.region">region</h2>
 
 
 The region this unit is in.
 
-<h2 id="requires.AWSRequires.tag_instance">tag_instance</h2>
+<h2 id="requires.AWSIntegrationRequires.tag_instance">tag_instance</h2>
 
 ```python
-AWSRequires.tag_instance(self, tags)
+AWSIntegrationRequires.tag_instance(self, tags)
 ```
 
 Request that the given tags be applied to this instance.
@@ -67,10 +67,10 @@ __Parameters__
 
 - __`tags` (dict)__: Mapping of tag names to values (or `None`).
 
-<h2 id="requires.AWSRequires.tag_instance_security_group">tag_instance_security_group</h2>
+<h2 id="requires.AWSIntegrationRequires.tag_instance_security_group">tag_instance_security_group</h2>
 
 ```python
-AWSRequires.tag_instance_security_group(self, tags)
+AWSIntegrationRequires.tag_instance_security_group(self, tags)
 ```
 
 Request that the given tags be applied to this instance's
@@ -80,10 +80,10 @@ __Parameters__
 
 - __`tags` (dict)__: Mapping of tag names to values (or `None`).
 
-<h2 id="requires.AWSRequires.tag_instance_subnet">tag_instance_subnet</h2>
+<h2 id="requires.AWSIntegrationRequires.tag_instance_subnet">tag_instance_subnet</h2>
 
 ```python
-AWSRequires.tag_instance_subnet(self, tags)
+AWSIntegrationRequires.tag_instance_subnet(self, tags)
 ```
 
 Request that the given tags be applied to this instance's subnet.
@@ -92,50 +92,50 @@ __Parameters__
 
 - __`tags` (dict)__: Mapping of tag names to values (or `None`).
 
-<h2 id="requires.AWSRequires.enable_instance_inspection">enable_instance_inspection</h2>
+<h2 id="requires.AWSIntegrationRequires.enable_instance_inspection">enable_instance_inspection</h2>
 
 ```python
-AWSRequires.enable_instance_inspection(self)
+AWSIntegrationRequires.enable_instance_inspection(self)
 ```
 
 Request the ability to inspect instances.
 
-<h2 id="requires.AWSRequires.enable_network_management">enable_network_management</h2>
+<h2 id="requires.AWSIntegrationRequires.enable_network_management">enable_network_management</h2>
 
 ```python
-AWSRequires.enable_network_management(self)
+AWSIntegrationRequires.enable_network_management(self)
 ```
 
 Request the ability to manage networking (firewalls, subnets, etc).
 
-<h2 id="requires.AWSRequires.enable_load_balancer_management">enable_load_balancer_management</h2>
+<h2 id="requires.AWSIntegrationRequires.enable_load_balancer_management">enable_load_balancer_management</h2>
 
 ```python
-AWSRequires.enable_load_balancer_management(self)
+AWSIntegrationRequires.enable_load_balancer_management(self)
 ```
 
 Request the ability to manage load balancers.
 
-<h2 id="requires.AWSRequires.enable_block_storage_management">enable_block_storage_management</h2>
+<h2 id="requires.AWSIntegrationRequires.enable_block_storage_management">enable_block_storage_management</h2>
 
 ```python
-AWSRequires.enable_block_storage_management(self)
+AWSIntegrationRequires.enable_block_storage_management(self)
 ```
 
 Request the ability to manage block storage.
 
-<h2 id="requires.AWSRequires.enable_dns_management">enable_dns_management</h2>
+<h2 id="requires.AWSIntegrationRequires.enable_dns_management">enable_dns_management</h2>
 
 ```python
-AWSRequires.enable_dns_management(self)
+AWSIntegrationRequires.enable_dns_management(self)
 ```
 
 Request the ability to manage DNS.
 
-<h2 id="requires.AWSRequires.enable_object_storage_access">enable_object_storage_access</h2>
+<h2 id="requires.AWSIntegrationRequires.enable_object_storage_access">enable_object_storage_access</h2>
 
 ```python
-AWSRequires.enable_object_storage_access(self, patterns=None)
+AWSIntegrationRequires.enable_object_storage_access(self, patterns=None)
 ```
 
 Request the ability to access object storage.
@@ -144,12 +144,12 @@ __Parameters__
 
 - __`patterns` (list)__: If given, restrict access to the resources matching
     the patterns. If patterns do not start with the S3 ARN prefix
-- __(`arn:aws:s3::__:`), it will be prepended.
+- __(`arn__:aws:s3:::`), it will be prepended.
 
-<h2 id="requires.AWSRequires.enable_object_storage_management">enable_object_storage_management</h2>
+<h2 id="requires.AWSIntegrationRequires.enable_object_storage_management">enable_object_storage_management</h2>
 
 ```python
-AWSRequires.enable_object_storage_management(self, patterns=None)
+AWSIntegrationRequires.enable_object_storage_management(self, patterns=None)
 ```
 
 Request the ability to manage object storage.
@@ -158,5 +158,5 @@ __Parameters__
 
 - __`patterns` (list)__: If given, restrict management to the resources
     matching the patterns. If patterns do not start with the S3 ARN
-- __prefix (`arn:aws:s3::__:`), it will be prepended.
+- __prefix (`arn__:aws:s3:::`), it will be prepended.
 

--- a/interface.yaml
+++ b/interface.yaml
@@ -1,4 +1,4 @@
-name: aws
-summary: Interface for connecting to the AWS integration charm.
+name: aws-integration
+summary: Interface for connecting to the AWS integrator charm.
 version: 1
 maintainer: Cory Johns <cory.johns@canonical.com>

--- a/make_docs
+++ b/make_docs
@@ -8,8 +8,10 @@ import pydocmd.__main__
 
 
 with patch('charmhelpers.core.hookenv.metadata') as metadata:
-    metadata.return_value = {'requires': {'aws': {'interface': 'aws'}},
-                             'provides': {'aws': {'interface': 'aws'}}}
+    metadata.return_value = {
+        'requires': {'aws': {'interface': 'aws-integration'}},
+        'provides': {'aws': {'interface': 'aws-integration'}},
+    }
     sys.path.insert(0, '.')
     print(sys.argv)
     if len(sys.argv) == 1:

--- a/provides.py
+++ b/provides.py
@@ -1,6 +1,6 @@
 """
 This is the provides side of the interface layer, for use only by the AWS
-integration charm itself.
+integrator charm itself.
 
 The flags that are set by the provides side of this interface are:
 
@@ -21,7 +21,7 @@ from charms.reactive import when
 from charms.reactive import toggle_flag, clear_flag
 
 
-class AWSProvides(Endpoint):
+class AWSIntegrationProvides(Endpoint):
     """
     Example usage:
 

--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -3,10 +3,10 @@ site_name: 'AWS Integration Interface'
 generate:
   - requires.md:
     - requires
-    - requires.AWSRequires+
+    - requires.AWSIntegrationRequires+
   - provides.md:
     - provides
-    - provides.AWSProvides+
+    - provides.AWSIntegrationProvides+
     - provides.IntegrationRequest+
 
 pages:

--- a/requires.py
+++ b/requires.py
@@ -37,7 +37,7 @@ from charms.reactive import clear_flag, toggle_flag
 READ_BLOCK_SIZE = 2048
 
 
-class AWSRequires(Endpoint):
+class AWSIntegrationRequires(Endpoint):
     """
     Example usage:
 


### PR DESCRIPTION
With the creation of the OpenStack integrator charm, it has become clear that the bare cloud name is a confusing naming convention.  So we're renaming the charms to `-integrator` and the interfaces to
`-integration`.