### PR TITLE
Implementation of ops requires side of aws interface

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,5 +12,7 @@ jobs:
   lint-unit:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
+    with:
+      python: "['3.8', '3.9', '3.10', '3.11', '3.12']"
     needs:
       - call-inclusive-naming-check 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .tox
 __pycache__
+*.egg-info/
+.coverage

--- a/ops/ops/interface_aws/requires.py
+++ b/ops/ops/interface_aws/requires.py
@@ -70,15 +70,15 @@ class AWSIntegrationRequires(ops.Object):
             self.aws = AwsIntegrationRequires(self)
             ...
 
-        def request_aws_integration():
+        def request_aws_integration(self):
             self.aws.request_instance_tags({
                 'tag1': 'value1',
                 'tag2': None,
             })
-            aws.request_load_balancer_management()
+            self.aws.request_load_balancer_management()
             # ...
 
-        def check_aws_integration():
+        def check_aws_integration(self):
             if self.aws.is_ready():
                 update_config_enable_aws()
         ```

--- a/ops/ops/interface_aws/requires.py
+++ b/ops/ops/interface_aws/requires.py
@@ -124,6 +124,12 @@ class AWSIntegrationRequires(ops.Object):
         return {}
 
     def _joined(self, _):
+        log.info(
+            "%s is instance=%s in region=%s",
+            self.charm.unit.name,
+            self.instance_id,
+            self.region,
+        )
         self._to_publish["instance-id"] = self.instance_id
         self._to_publish["region"] = self.region
 

--- a/ops/pyproject.toml
+++ b/ops/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ops.interface_aws"
+version = "0.1.0"
+authors = [
+  {name="Canonical Kubernetes", email="k8s-crew@lists.canonical.com"},
+]
+description = "Charm library for installing and configuring aws integration"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+  "ops",
+  "packaging",
+]
+classifiers = [
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/charmed-kubernetes/interace-aws-integration"
+"Bug Tracker" = "https://github.com/charmed-kubernetes/interace-aws-integration/issues"
+
+[tool.setuptools.packages.find]
+include = ["ops.*"]

--- a/ops/tests/data/aws_recv.yaml
+++ b/ops/tests/data/aws_recv.yaml
@@ -1,1 +1,1 @@
-completed: '{"i-abcdefghijklmnopq": "1fca8013323a5aaa67a9a816ab1b910a2402165c198f8502c69d7c0b2a0546cf"}'
+completed: '{"i-abcdefghijklmnopq": "3577342edb3a0a9a4b6861b7d2f580f35db2709e92f3ddd17bb027eb85a2f670"}'

--- a/ops/tests/data/aws_recv.yaml
+++ b/ops/tests/data/aws_recv.yaml
@@ -1,0 +1,1 @@
+completed: '{"i-abcdefghijklmnopq": "1fca8013323a5aaa67a9a816ab1b910a2402165c198f8502c69d7c0b2a0546cf"}'

--- a/ops/tests/data/aws_sent.yaml
+++ b/ops/tests/data/aws_sent.yaml
@@ -13,7 +13,7 @@ ingress-address: 172.31.39.57
 instance-id: '"i-abcdefghijklmnopq"'
 instance-security-group-tags: '{"kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'
 instance-subnet-tags: '{"kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'
-instance-tags: '{"k8s.io/role/control-plane": "true", "kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'
+instance-tags: '{"tag1": "true", "tag2": "false"}'
 enable-object-storage-management: "true"
 object-storage-management-patterns: '["arn:aws:s3:::auto-prefixed", "arn:aws:s3:::already-prefixed"]'
 enable-object-storage-access: "true"

--- a/ops/tests/data/aws_sent.yaml
+++ b/ops/tests/data/aws_sent.yaml
@@ -1,0 +1,23 @@
+egress-subnets: 172.31.39.57/32
+enable-acm-readonly: "true"
+enable-acm-fullaccess: "true"
+enable-autoscaling-readonly: "true"
+enable-block-storage-management: "true"
+enable-dns-management: "true"
+enable-instance-inspection: "true"
+enable-instance-modification: "true"
+enable-load-balancer-management: "true"
+enable-network-management: "true"
+enable-region-readonly: "true"
+ingress-address: 172.31.39.57
+instance-id: '"i-abcdefghijklmnopq"'
+instance-security-group-tags: '{"kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'
+instance-subnet-tags: '{"kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'
+instance-tags: '{"k8s.io/role/master": "true", "kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'
+enable-object-storage-management: "true"
+object-storage-management-patterns: '["arn:aws:s3:::auto-prefixed", "arn:aws:s3:::already-prefixed"]'
+enable-object-storage-access: "true"
+object-storage-access-patterns: '["arn:aws:s3:::auto-prefixed", "arn:aws:s3:::already-prefixed"]'
+private-address: 172.31.39.57
+region: '"us-east-1"'
+requested: "true"

--- a/ops/tests/data/aws_sent.yaml
+++ b/ops/tests/data/aws_sent.yaml
@@ -13,7 +13,7 @@ ingress-address: 172.31.39.57
 instance-id: '"i-abcdefghijklmnopq"'
 instance-security-group-tags: '{"kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'
 instance-subnet-tags: '{"kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'
-instance-tags: '{"k8s.io/role/master": "true", "kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'
+instance-tags: '{"k8s.io/role/control-plane": "true", "kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'
 enable-object-storage-management: "true"
 object-storage-management-patterns: '["arn:aws:s3:::auto-prefixed", "arn:aws:s3:::already-prefixed"]'
 enable-object-storage-access: "true"

--- a/ops/tests/unit/test_ops_requires.py
+++ b/ops/tests/unit/test_ops_requires.py
@@ -1,29 +1,43 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 import io
 import json
 import unittest.mock as mock
-from collections import defaultdict
+from urllib.error import URLError
+from urllib.parse import urljoin
 from pathlib import Path
 
 import pytest
 import yaml
 import ops
 import ops.testing
-from ops.interface_aws.requires import AWSIntegrationRequires,  _METADATAV2_TOKEN_URL
+from ops.interface_aws.requires import (
+    AWSIntegrationError,
+    AWSIntegrationRequires,
+    _metadata,
+    _METADATA_URL,
+    _METADATAV2_TOKEN_URL,
+    _INSTANCE_ID_URL,
+    _AZ_URL,
+)
 
 
 class MyCharm(ops.CharmBase):
-    aws_meta = ops.RelationMeta(ops.RelationRole.requires, "aws", {"interface": "aws-integratoin"})
+    aws_meta = ops.RelationMeta(
+        ops.RelationRole.requires, "aws", {"interface": "aws-integration"}
+    )
 
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
         self.aws = AWSIntegrationRequires(self)
 
+
 @pytest.fixture(scope="function")
 def harness():
     harness = ops.testing.Harness(MyCharm)
-    harness.framework.meta.relations={MyCharm.aws_meta.relation_name: MyCharm.aws_meta}
+    harness.framework.meta.relations = {
+        MyCharm.aws_meta.relation_name: MyCharm.aws_meta
+    }
     harness.set_model_name("test/0")
     harness.begin_with_initial_hooks()
     yield harness
@@ -32,13 +46,16 @@ def harness():
 @pytest.fixture(autouse=True)
 def mock_url():
     with mock.patch("ops.interface_aws.requires.urlopen") as urlopen:
+
         def urlopener(req):
             if req.full_url == _METADATAV2_TOKEN_URL:
                 return io.BytesIO(b"faux-token")
-            elif req.full_url.endswith("instance-id"):
+            elif req.full_url == _INSTANCE_ID_URL:
                 return io.BytesIO(b"i-abcdefghijklmnopq")
-            elif req.full_url.endswith("availability-zone"):
+            elif req.full_url == _AZ_URL:
                 return io.BytesIO(b"us-east1")
+            else:
+                raise URLError("Test Framework")
 
         urlopen.side_effect = urlopener
         yield urlopen
@@ -52,6 +69,12 @@ def sent_data():
 @pytest.fixture()
 def recv_data():
     yield yaml.safe_load(Path("tests/data/aws_recv.yaml").open())
+
+
+@pytest.mark.usefixtures("mock_url")
+def test_metadata_fail():
+    with pytest.raises(AWSIntegrationError):
+        _metadata(urljoin(_METADATA_URL, "/invalid/address"))
 
 
 @pytest.mark.parametrize(
@@ -87,11 +110,21 @@ def test_is_ready_success(harness, recv_data):
     assert harness.charm.aws.evaluate_relation(event) is None
 
 
-@pytest.mark.parametrize("method_name, args", 
+@pytest.mark.parametrize(
+    "method_name, args",
     [
-        ("tag_instance", 'tags={"k8s.io/role/control-plane": "true", "kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'),
-        ("tag_instance_security_group", 'tags={"kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'),
-        ("tag_instance_subnet", 'tags={"kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'),
+        (
+            "tag_instance",
+            'tags={"k8s.io/role/control-plane": "true", "kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}',
+        ),
+        (
+            "tag_instance_security_group",
+            'tags={"kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}',
+        ),
+        (
+            "tag_instance_subnet",
+            'tags={"kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}',
+        ),
         ("enable_acm_readonly", None),
         ("enable_acm_fullaccess", None),
         ("enable_autoscaling_readonly", None),
@@ -102,7 +135,7 @@ def test_is_ready_success(harness, recv_data):
         ("enable_block_storage_management", None),
         ("enable_dns_management", None),
         ("enable_region_readonly", None),
-    ]
+    ],
 )
 def test_request_simple(harness, method_name, args, sent_data):
     rel_id = harness.add_relation("aws", "remote")

--- a/ops/tests/unit/test_ops_requires.py
+++ b/ops/tests/unit/test_ops_requires.py
@@ -115,7 +115,7 @@ def test_is_ready_success(harness, recv_data):
     [
         (
             "tag_instance",
-            'tags={"k8s.io/role/control-plane": "true", "kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}',
+            'tags={"tag1": "true", "tag2": "false"}',
         ),
         (
             "tag_instance_security_group",

--- a/ops/tests/unit/test_ops_requires.py
+++ b/ops/tests/unit/test_ops_requires.py
@@ -1,0 +1,127 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+import io
+import json
+import unittest.mock as mock
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+import yaml
+import ops
+import ops.testing
+from ops.interface_aws.requires import AWSIntegrationRequires,  _METADATAV2_TOKEN_URL
+
+
+class MyCharm(ops.CharmBase):
+    aws_meta = ops.RelationMeta(ops.RelationRole.requires, "aws", {"interface": "aws-integratoin"})
+
+    def __init__(self, framework: ops.Framework):
+        super().__init__(framework)
+        self.aws = AWSIntegrationRequires(self)
+
+@pytest.fixture(scope="function")
+def harness():
+    harness = ops.testing.Harness(MyCharm)
+    harness.framework.meta.relations={MyCharm.aws_meta.relation_name: MyCharm.aws_meta}
+    harness.set_model_name("test/0")
+    harness.begin_with_initial_hooks()
+    yield harness
+
+
+@pytest.fixture(autouse=True)
+def mock_url():
+    with mock.patch("ops.interface_aws.requires.urlopen") as urlopen:
+        def urlopener(req):
+            if req.full_url == _METADATAV2_TOKEN_URL:
+                return io.BytesIO(b"faux-token")
+            elif req.full_url.endswith("instance-id"):
+                return io.BytesIO(b"i-abcdefghijklmnopq")
+            elif req.full_url.endswith("availability-zone"):
+                return io.BytesIO(b"us-east1")
+
+        urlopen.side_effect = urlopener
+        yield urlopen
+
+
+@pytest.fixture()
+def sent_data():
+    yield yaml.safe_load(Path("tests/data/aws_sent.yaml").open())
+
+
+@pytest.fixture()
+def recv_data():
+    yield yaml.safe_load(Path("tests/data/aws_recv.yaml").open())
+
+
+@pytest.mark.parametrize(
+    "event_type", [None, ops.RelationBrokenEvent], ids=["unrelated", "dropped relation"]
+)
+def test_is_ready_no_relation(harness, event_type):
+    event = ops.ConfigChangedEvent(None)
+    assert harness.charm.aws.is_ready is False
+    assert "Missing" in harness.charm.aws.evaluate_relation(event)
+
+    rel_id = harness.add_relation("aws", "remote")
+    assert harness.charm.aws.is_ready is False
+
+    rel = harness.model.get_relation("aws", rel_id)
+    harness.add_relation_unit(rel_id, "remote/0")
+    event = ops.RelationJoinedEvent(None, rel)
+    assert "Waiting" in harness.charm.aws.evaluate_relation(event)
+
+    event = ops.RelationChangedEvent(None, rel)
+    harness.update_relation_data(rel_id, "remote/0", {"completed": "{}"})
+    assert "Waiting" in harness.charm.aws.evaluate_relation(event)
+
+    if event_type:
+        harness.remove_relation(rel_id)
+        event = event_type(None, rel)
+        assert "Missing" in harness.charm.aws.evaluate_relation(event)
+
+
+def test_is_ready_success(harness, recv_data):
+    harness.add_relation("aws", "remote", unit_data=recv_data)
+    assert harness.charm.aws.is_ready is True
+    event = ops.ConfigChangedEvent(None)
+    assert harness.charm.aws.evaluate_relation(event) is None
+
+
+@pytest.mark.parametrize("method_name, args", 
+    [
+        ("tag_instance", 'tags={"k8s.io/role/master": "true", "kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'),
+        ("tag_instance_security_group", 'tags={"kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'),
+        ("tag_instance_subnet", 'tags={"kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'),
+        ("enable_acm_readonly", None),
+        ("enable_acm_fullaccess", None),
+        ("enable_autoscaling_readonly", None),
+        ("enable_instance_inspection", None),
+        ("enable_instance_modification", None),
+        ("enable_network_management", None),
+        ("enable_load_balancer_management", None),
+        ("enable_block_storage_management", None),
+        ("enable_dns_management", None),
+        ("enable_region_readonly", None),
+    ]
+)
+def test_request_simple(harness, method_name, args, sent_data):
+    rel_id = harness.add_relation("aws", "remote")
+    method = getattr(harness.charm.aws, method_name)
+    kwargs = {}
+    if args:
+        kw, val = args.split("=")
+        kwargs[kw] = json.loads(val)
+    method(**kwargs)
+    data = harness.get_relation_data(rel_id, harness.charm.unit.name)
+    for each, value in data.items():
+        assert sent_data[each] == value
+
+
+def test_request_object_storage(harness, sent_data):
+    rel_id = harness.add_relation("aws", "remote")
+    patterns = ["auto-prefixed", "arn:aws:s3:::already-prefixed"]
+    harness.charm.aws.enable_object_storage_access(patterns)
+    harness.charm.aws.enable_object_storage_management(patterns)
+    data = harness.get_relation_data(rel_id, harness.charm.unit.name)
+    for each, value in data.items():
+        assert sent_data[each] == value

--- a/ops/tests/unit/test_ops_requires.py
+++ b/ops/tests/unit/test_ops_requires.py
@@ -89,7 +89,7 @@ def test_is_ready_success(harness, recv_data):
 
 @pytest.mark.parametrize("method_name, args", 
     [
-        ("tag_instance", 'tags={"k8s.io/role/master": "true", "kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'),
+        ("tag_instance", 'tags={"k8s.io/role/control-plane": "true", "kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'),
         ("tag_instance_security_group", 'tags={"kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'),
         ("tag_instance_subnet", 'tags={"kubernetes.io/cluster/kubernetes-generated-cluster-name": "owned"}'),
         ("enable_acm_readonly", None),

--- a/ops/tox.ini
+++ b/ops/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+envlist = unit
+
+[vars]
+tst_path = {toxinidir}/tests
+
+[testenv]
+basepython = python3
+setenv =
+  PYTHONPATH = {toxinidir}
+
+[testenv:unit]
+deps =
+    pytest-cov
+    pytest-html
+commands =
+    pytest \
+      -vv \
+      --cov='{envsitepackagesdir}/ops/interface_aws' \
+	    --cov-report=term-missing \
+      --tb=native \
+      {posargs:{[vars]tst_path}/unit}
+
+[flake8]
+exclude=.tox
+max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -20,15 +20,15 @@ commands =
 [testenv:format]
 envdir = {toxworkdir}/lint
 deps = black
-commands = black {toxinidir}/requires.py {toxinidir}/provides.py
+commands = black {toxinidir}/requires.py {toxinidir}/provides.py {toxinidir}/ops
 
 [testenv:lint]
 deps = 
     flake8
     black
 commands = 
-    flake8 {toxinidir}/requires.py {toxinidir}/provides.py
-    black --check {toxinidir}/requires.py {toxinidir}/provides.py
+    flake8 {toxinidir}/requires.py {toxinidir}/provides.py {toxinidir}/ops
+    black --check {toxinidir}/requires.py {toxinidir}/provides.py {toxinidir}/ops
 
 [testenv:unit]
 deps = 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py3
 skipsdist = true
 
 [testenv]
+allowlist_externals=tox
 basepython=python3
 envdir={toxworkdir}/py3
 deps=
@@ -31,7 +32,7 @@ commands =
 
 [testenv:unit]
 deps = 
-commands = python -c "print('-No tests found-')"
+commands=tox -c {toxinidir}/ops/ -e unit
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Addition of an `ops` interface for the `aws-integration` relation

This allows `ops` charms to request instance features of aws over the aws-integration relation.